### PR TITLE
fix: searchbox handler was not always rerouting to /search

### DIFF
--- a/components/bars/MainBar/Searchbox.tsx
+++ b/components/bars/MainBar/Searchbox.tsx
@@ -16,9 +16,7 @@ const Searchbox = ({ updateSearchValue }: SearchboxProps) => {
   const handleSearch = () => {
     if (searchValue.trim()) {
       updateSearchValue(searchValue);
-      if (!router.pathname.includes("/search")) {
-        router.push("/search");
-      }
+      router.push("/search");
     }
   };
 

--- a/hooks/useUserData.tsx
+++ b/hooks/useUserData.tsx
@@ -342,6 +342,8 @@ export const useDataProvider = () => {
         if (matchingSnippet) {
           setActiveSnippetId(matchingSnippet._id.toString());
           return { valid: true };
+        } else {
+          return { valid: false };
         }
       } else {
         setActiveSnippetId("");


### PR DESCRIPTION
On every search we need to reroute to "/search" because it handles the incoming searchValue and checks for matching snippets and then reroutes to /search/[snippetId] with the first default snippet that matches. But when the search was being made from /search/[snippetId] the handler would not reroute as it was only looking if the path does not INCLUDE "/search". Now it reroutes everytime no matter the current path.